### PR TITLE
Remove Roboto Mono as the default.

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,11 +1,11 @@
 'use strict';
 
 module.exports = function() {
-    return { 
+    return {
         webFontConfig: {
-            google: {
-                families: ['Roboto Mono']
-            }
-        } 
+            // google: {
+            //     families: ['Roboto Mono']
+            // }
+        }
     };
 };


### PR DESCRIPTION
Fixes #1.

Addon's config/environment.js is merged with app's config.environment.js and this can't be overwritten unless user is also using a Google font.
